### PR TITLE
Deduplicate games

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,10 @@ SELECT games.serial_id,
 	games.release_year,
 	games.release_month,
 	games.display_name,
+	games.users,
 	developers.name as developer_name,
+	publishers.name as publisher_name,
+	ratings.name as rating_name,	
 	franchises.name as franchise_name,
 	regions.name as region_name,
 	genres.name as genre_name,
@@ -119,11 +122,13 @@ SELECT games.serial_id,
 FROM games
 	LEFT JOIN developers ON games.developer_id = developers.id
 	LEFT JOIN franchises ON games.franchise_id = franchises.id
+	LEFT JOIN publishers ON games.publisher_id = publishers.id
+	LEFT JOIN ratings ON games.rating_id = ratings.id
 	LEFT JOIN genres ON games.genre_id = genres.id
 	LEFT JOIN platforms ON games.platform_id = platforms.id
 		LEFT JOIN manufacturers ON platforms.manufacturer_id = manufacturers.id
 	LEFT JOIN regions ON games.region_id = regions.id
-	INNER JOIN roms ON games.rom_id = roms.id
+	INNER JOIN roms ON games.serial_id = roms.serial_id
 WHERE roms.md5 = "27F322F5CD535297AB21BC4A41CBFC12";
 ```
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ the same content* from the Libretro RetroArch database in a single SQLite databa
 
 ***Important note:*** The conversion tool here also does some basic deconfliction when there are multiple records for the same ROM MD5 checksum.
 The underlying assumption is that if two ROMs have the same checksum, they're the same, and the metadata should be merged in favor of non-null
-values. The primary use-case is for client applications to be able to query the database by MD5 checksum of a ROM file, so keep in mind that this mindset informed the database schema and how the utility decides which data is duplicated.
+values. The primary use-case is for client applications to be able to query the database by MD5 checksum of a ROM file, so keep in mind that 
+this mindset informed the database schema and how the utility decides which data is duplicated.
 
 ## Usage
 
@@ -37,8 +38,10 @@ build/libretrodb.sqlite.tgz
 | ------ | --------- |
 | id | INTEGER PRIMARY KEY |
 | serial_id | TEXT |
-| rom_id | INTEGER |
 | developer_id | INTEGER |
+| publisher_id | INTEGER |
+| rating_id | INTEGER |
+| users | INTEGER |
 | franchise_id | INTEGER |
 | release_year | INTEGER |
 | release_month | INTEGER |
@@ -54,10 +57,25 @@ build/libretrodb.sqlite.tgz
 | Column | Data Type |
 | ------ | --------- |
 | id | INTEGER PRIMARY KEY |
+| serial_id | INTEGER |
 | name | TEXT |
 | md5 | TEXT |
 
 ### `developers`
+
+| Column | Data Type |
+| ------ | --------- |
+| id | INTEGER PRIMARY KEY |
+| name | TEXT |
+
+### `publishers`
+
+| Column | Data Type |
+| ------ | --------- |
+| id | INTEGER PRIMARY KEY |
+| name | TEXT |
+
+### `ratings`
 
 | Column | Data Type |
 | ------ | --------- |

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-<img src="https://img.shields.io/badge/size-37%20MB-blue"></img>
-<img src="https://img.shields.io/badge/compressed%20size-13%20MB-blue"></img>
+<img src="https://img.shields.io/badge/size-35%20MB-blue"></img>
+<img src="https://img.shields.io/badge/compressed%20size-14%20MB-blue"></img>
 
 # SQLite Libretro DB
 

--- a/main.py
+++ b/main.py
@@ -372,11 +372,9 @@ class Converter:
     def _insert_games(self, cursor):
         for key,value in self.games.items():
             game = value
-            # cursor.execute(self._load_sql("./sql/insert_rom.sql"), (game.rom.id, game.rom.name, game.rom.md5))
             cursor.execute(self._load_sql("./sql/insert_game.sql"), (
                 game.id, 
                 game.serial,
-                # game.rom.id,
                 game.developer_id,
                 game.publisher_id,
                 game.rating_id,

--- a/main.py
+++ b/main.py
@@ -393,7 +393,6 @@ class Converter:
     Insert the ROMs into the database.
     """
     def _insert_roms(self, cursor):
-        # cursor.execute(self._load_sql("./sql/insert_rom.sql"), (game.rom.id, game.rom.name, game.rom.md5))
         for key,value in self.roms.items():
             rom = value
             cursor.execute(self._load_sql("./sql/insert_rom.sql"), (rom.id, rom.serial, rom.name, rom.md5))

--- a/main.py
+++ b/main.py
@@ -47,7 +47,6 @@ class Game:
         self.display_name = display_name
         self.full_name = full_name
         self.serial = serial
-        # self.rom = rom
         self.developer_id = developer_id
         self.publisher_id = publisher_id
         self.rating_id = rating_id
@@ -63,7 +62,6 @@ class Game:
     Merge other game into self by deferring to non-null fields.
     """
     def join(self, other):
-        # Join the top-level fields
         if self.display_name is None and other.display_name is not None:
             self.display_name = other.display_name
         if self.full_name is None and other.full_name is not None:
@@ -90,13 +88,6 @@ class Game:
             self.genre_id = other.genre_id
         if self.platform_id is None and other.platform_id is not None:
             self.platform_id = other.platform_id
-        # Join the ROM
-        # if self.rom is None and other.rom is not None:
-        #     self.rom = other.rom
-        # if self.rom.name is None and other.rom.name is not None:
-        #     self.rom.name = other.rom.name
-        # if self.rom.md5 is None and other.rom.md5 is not None:
-        #     self.rom.md5 = other.rom.md5
 
 class Converter:
 
@@ -303,8 +294,6 @@ class Converter:
             id = len(self.games) + 1
             game.id = id
             self.games[serial] = game
-            # self.games[serial].id = id
-            # self.games[md5].rom.id = id
     
     """
     Insert the manufacturers into the database.

--- a/sql/create_tables.sql
+++ b/sql/create_tables.sql
@@ -1,8 +1,11 @@
 CREATE TABLE games (
     id INTEGER PRIMARY KEY,
     serial_id TEXT,
-    rom_id INTEGER,
+    -- rom_id INTEGER,
     developer_id INTEGER,
+    publisher_id INTEGER,
+    rating_id INTEGER,
+    users INTEGER,
     franchise_id INTEGER,
     release_year INTEGER,
     release_month INTEGER,
@@ -15,10 +18,19 @@ CREATE TABLE games (
 );
 CREATE TABLE roms (
     id INTEGER PRIMARY KEY,
+    serial_id TEXT,
     name TEXT,
     md5 TEXT
 );
 CREATE TABLE developers (
+    id INTEGER PRIMARY KEY,
+    name TEXT
+);
+CREATE TABLE publishers (
+    id INTEGER PRIMARY KEY,
+    name TEXT
+);
+CREATE TABLE ratings (
     id INTEGER PRIMARY KEY,
     name TEXT
 );

--- a/sql/create_tables.sql
+++ b/sql/create_tables.sql
@@ -1,7 +1,6 @@
 CREATE TABLE games (
     id INTEGER PRIMARY KEY,
     serial_id TEXT,
-    -- rom_id INTEGER,
     developer_id INTEGER,
     publisher_id INTEGER,
     rating_id INTEGER,

--- a/sql/insert_game.sql
+++ b/sql/insert_game.sql
@@ -1,7 +1,6 @@
 INSERT INTO games(
     id,
     serial_id,
-    -- rom_id,
     developer_id,
     publisher_id,
     rating_id,

--- a/sql/insert_game.sql
+++ b/sql/insert_game.sql
@@ -1,8 +1,11 @@
 INSERT INTO games(
     id,
     serial_id,
-    rom_id,
+    -- rom_id,
     developer_id,
+    publisher_id,
+    rating_id,
+    users,
     franchise_id,
     release_year,
     release_month,
@@ -12,4 +15,4 @@ INSERT INTO games(
     full_name,
     -- boxart_url,
     platform_id
-) VALUES(?,?,?,?,?,?,?,?,?,?,?,?)
+) VALUES(?,?,?,?,?,?,?,?,?,?,?,?,?,?)

--- a/sql/insert_publisher.sql
+++ b/sql/insert_publisher.sql
@@ -1,0 +1,1 @@
+INSERT INTO publishers(id,name) VALUES(?,?)

--- a/sql/insert_rating.sql
+++ b/sql/insert_rating.sql
@@ -1,0 +1,1 @@
+INSERT INTO ratings(id,name) VALUES(?,?)

--- a/sql/insert_rom.sql
+++ b/sql/insert_rom.sql
@@ -1,1 +1,1 @@
-INSERT INTO roms(id,name,md5) VALUES(?,?,?)
+INSERT INTO roms(id,serial_id,name,md5) VALUES(?,?,?,?)


### PR DESCRIPTION
Deduplicate games by leveraging the serial ID to allow multiple ROMs to reference a single game entry. This allows filling in more "missing" data where multiple ROMs (different checksums) are the same game, but only one row in the original dataset contained all the metadata.